### PR TITLE
Add CANrange support for scoring mechanism

### DIFF
--- a/src/main/java/com/team1165/robot/OdysseusManager.java
+++ b/src/main/java/com/team1165/robot/OdysseusManager.java
@@ -43,8 +43,8 @@ public class OdysseusManager extends RobotManager<OdysseusState> {
     return flywheel.getDetectionMode();
   }
 
-  public boolean getFlywheelCurrentHold(double current) {
-    return flywheel.getCurrentHold(current);
+  public double getFlywheelCurrent() {
+    return flywheel.getCurrent();
   }
 
   public boolean getFlywheelSensorHold() {

--- a/src/main/java/com/team1165/robot/OdysseusManager.java
+++ b/src/main/java/com/team1165/robot/OdysseusManager.java
@@ -38,11 +38,6 @@ public class OdysseusManager extends RobotManager<OdysseusState> {
     this.funnel = funnel;
   }
 
-  public double getFlywheelCurrent() {
-    // TODO: Maybe goals should be used for this?
-    return flywheel.getOutputCurrent();
-  }
-
   public boolean getElevatorAtGoal(double tolerance) {
     return elevator.atGoal(tolerance);
   }

--- a/src/main/java/com/team1165/robot/OdysseusManager.java
+++ b/src/main/java/com/team1165/robot/OdysseusManager.java
@@ -11,6 +11,7 @@ import com.team1165.robot.subsystems.elevator.Elevator;
 import com.team1165.robot.subsystems.elevator.ElevatorState;
 import com.team1165.robot.subsystems.roller.flywheel.Flywheel;
 import com.team1165.robot.subsystems.roller.flywheel.FlywheelState;
+import com.team1165.robot.subsystems.roller.flywheel.sensor.DetectionMode;
 import com.team1165.robot.subsystems.roller.funnel.Funnel;
 import com.team1165.robot.subsystems.roller.funnel.FunnelState;
 import com.team1165.robot.util.statemachine.RobotManager;
@@ -36,6 +37,18 @@ public class OdysseusManager extends RobotManager<OdysseusState> {
     this.elevator = elevator;
     this.flywheel = flywheel;
     this.funnel = funnel;
+  }
+
+  public DetectionMode getFlywheelDetectionMode() {
+    return flywheel.getDetectionMode();
+  }
+
+  public boolean getFlywheelCurrentHold(double current) {
+    return flywheel.getCurrentHold(current);
+  }
+
+  public boolean getFlywheelSensorHold() {
+    return flywheel.getSensorHold();
   }
 
   public boolean getElevatorAtGoal(double tolerance) {

--- a/src/main/java/com/team1165/robot/RobotContainer.java
+++ b/src/main/java/com/team1165/robot/RobotContainer.java
@@ -28,6 +28,8 @@ import com.team1165.robot.subsystems.elevator.io.ElevatorIOTempSim;
 import com.team1165.robot.subsystems.roller.flywheel.Flywheel;
 import com.team1165.robot.subsystems.roller.flywheel.FlywheelConstants;
 import com.team1165.robot.subsystems.roller.flywheel.FlywheelState;
+import com.team1165.robot.subsystems.roller.flywheel.sensor.SensorIO;
+import com.team1165.robot.subsystems.roller.flywheel.sensor.SensorIOCTRE;
 import com.team1165.robot.subsystems.roller.funnel.Funnel;
 import com.team1165.robot.subsystems.roller.funnel.FunnelConstants;
 import com.team1165.robot.subsystems.roller.funnel.FunnelState;
@@ -97,7 +99,7 @@ public class RobotContainer {
         flywheel =
             new Flywheel(
                 new RollerIOSpark(
-                    FlywheelConstants.primaryMotorConfig, FlywheelConstants.secondaryMotorConfig));
+                    FlywheelConstants.primaryMotorConfig, FlywheelConstants.secondaryMotorConfig), new SensorIOCTRE(FlywheelConstants.sensorConfig));
 
         funnel =
             new Funnel(
@@ -136,7 +138,7 @@ public class RobotContainer {
         // TODO: Add simulation IO for Elevator
         elevator = new Elevator(new ElevatorIOTempSim());
 
-        flywheel = new Flywheel(new RollerIOSim(FlywheelConstants.simConfig, Amps.of(50)));
+        flywheel = new Flywheel(new RollerIOSim(FlywheelConstants.simConfig, Amps.of(50)), new SensorIO() {});
 
         funnel = new Funnel(new RollerIOSim(FunnelConstants.simConfig, Amps.of(40)));
 
@@ -171,7 +173,7 @@ public class RobotContainer {
         // Replayed robot, disable IO implementations
         drive = new Drive(new DriveIO() {});
         elevator = new Elevator(new ElevatorIO() {});
-        flywheel = new Flywheel(new RollerIO() {});
+        flywheel = new Flywheel(new RollerIO() {}, new SensorIO() {});
         funnel = new Funnel(new RollerIO() {});
         apriltagVision =
             new ATVision(

--- a/src/main/java/com/team1165/robot/RobotContainer.java
+++ b/src/main/java/com/team1165/robot/RobotContainer.java
@@ -99,7 +99,8 @@ public class RobotContainer {
         flywheel =
             new Flywheel(
                 new RollerIOSpark(
-                    FlywheelConstants.primaryMotorConfig, FlywheelConstants.secondaryMotorConfig), new SensorIOCTRE(FlywheelConstants.sensorConfig));
+                    FlywheelConstants.primaryMotorConfig, FlywheelConstants.secondaryMotorConfig),
+                new SensorIOCTRE(FlywheelConstants.sensorConfig));
 
         funnel =
             new Funnel(
@@ -138,7 +139,9 @@ public class RobotContainer {
         // TODO: Add simulation IO for Elevator
         elevator = new Elevator(new ElevatorIOTempSim());
 
-        flywheel = new Flywheel(new RollerIOSim(FlywheelConstants.simConfig, Amps.of(50)), new SensorIO() {});
+        flywheel =
+            new Flywheel(
+                new RollerIOSim(FlywheelConstants.simConfig, Amps.of(50)), new SensorIO() {});
 
         funnel = new Funnel(new RollerIOSim(FunnelConstants.simConfig, Amps.of(40)));
 

--- a/src/main/java/com/team1165/robot/commands/Intake.java
+++ b/src/main/java/com/team1165/robot/commands/Intake.java
@@ -13,6 +13,7 @@ import com.team1165.robot.subsystems.roller.flywheel.sensor.DetectionMode;
 import com.team1165.robot.util.logging.LoggedTunableNumber;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
+import org.littletonrobotics.junction.Logger;
 
 public class Intake extends Command {
 
@@ -49,13 +50,14 @@ public class Intake extends Command {
     var isCoralDetected =
         detectionMode == DetectionMode.DISTANCE_SENSOR
             ? robot.getFlywheelSensorHold()
-            : robot.getFlywheelCurrentHold(currentThreshold.get());
+            : Math.abs(robot.getFlywheelCurrent()) > currentThreshold.get();
 
     if (timer.hasElapsed(spinupTime.get())) {
       if (isCoralDetected && startingDetectionTimestamp == 0.0) {
         startingDetectionTimestamp = timer.get();
       }
 
+      Logger.recordOutput("Intake/Timer", timer.get() - startingDetectionTimestamp);
       if (isCoralDetected
           && timer.get() - startingDetectionTimestamp
               > (detectionMode == DetectionMode.DISTANCE_SENSOR
@@ -63,7 +65,7 @@ public class Intake extends Command {
                   : currentElapsedTime.get())) {
         endCommand = true;
         robot.setState(OdysseusState.IDLE);
-      } else {
+      } else if (!isCoralDetected) {
         startingDetectionTimestamp = 0.0;
       }
     }

--- a/src/main/java/com/team1165/robot/commands/Intake.java
+++ b/src/main/java/com/team1165/robot/commands/Intake.java
@@ -9,22 +9,25 @@ package com.team1165.robot.commands;
 
 import com.team1165.robot.OdysseusManager;
 import com.team1165.robot.OdysseusState;
+import com.team1165.robot.subsystems.roller.flywheel.sensor.DetectionMode;
 import com.team1165.robot.util.logging.LoggedTunableNumber;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 
 public class Intake extends Command {
+
   private static final LoggedTunableNumber currentThreshold =
       new LoggedTunableNumber("Commands/Intake/OverCurrentThreshold", 14);
-  private static final LoggedTunableNumber elapsedTime =
+  private static final LoggedTunableNumber currentElapsedTime =
       new LoggedTunableNumber("Commands/Intake/OverCurrentTime", 0.04);
+  private static final LoggedTunableNumber sensorElapsedTime = new LoggedTunableNumber(
+      "Commands/Intake/SensorElapsedTime", 0.04);
   private static final LoggedTunableNumber spinupTime =
       new LoggedTunableNumber("Commands/Intake/SpinupTime", 0.15);
 
   private final OdysseusManager robot;
   private final Timer timer = new Timer();
-  private double startingTimestampCurrent = 0.0;
-  private boolean didDrawHighCurrent = false;
+  private double startingDetectionTimestamp = 0.0;
   private boolean endCommand = false;
 
   public Intake(OdysseusManager robot) {
@@ -35,8 +38,6 @@ public class Intake extends Command {
   @Override
   public void initialize() {
     timer.restart();
-    startingTimestampCurrent = 0.0;
-    didDrawHighCurrent = false;
     endCommand = false;
     robot.setState(OdysseusState.INTAKE);
   }
@@ -44,28 +45,29 @@ public class Intake extends Command {
   @Override
   public void execute() {
     // TODO: Add a check to make sure elevator is down before fully intaking? Additional state.
-    var drawingHighCurrent = Math.abs(robot.getFlywheelCurrent()) > currentThreshold.get();
+    var detectionMode = robot.getFlywheelDetectionMode();
+    var isCoralDetected =
+        detectionMode == DetectionMode.DISTANCE_SENSOR ? robot.getFlywheelSensorHold()
+            : robot.getFlywheelCurrentHold(currentThreshold.get());
 
     if (timer.hasElapsed(spinupTime.get())) {
-      if (drawingHighCurrent && !didDrawHighCurrent) {
-        startingTimestampCurrent = timer.get();
-        didDrawHighCurrent = true;
+      if (isCoralDetected && startingDetectionTimestamp == 0.0) {
+        startingDetectionTimestamp = timer.get();
       }
 
-      if (drawingHighCurrent) {
-        if (timer.get() - startingTimestampCurrent > elapsedTime.get()) {
-          endCommand = true;
-          robot.setState(OdysseusState.IDLE);
-        }
-      } else if (didDrawHighCurrent) {
-        didDrawHighCurrent = false;
+      if (isCoralDetected && timer.get() - startingDetectionTimestamp > (
+          detectionMode == DetectionMode.DISTANCE_SENSOR ? sensorElapsedTime.get()
+              : currentElapsedTime.get())) {
+        endCommand = true;
+        robot.setState(OdysseusState.IDLE);
+      } else {
+        startingDetectionTimestamp = 0.0;
       }
     }
   }
 
   @Override
   public boolean isFinished() {
-    // TODO: Make this return true when this Command no longer needs to run execute()
     return endCommand;
   }
 

--- a/src/main/java/com/team1165/robot/commands/Intake.java
+++ b/src/main/java/com/team1165/robot/commands/Intake.java
@@ -20,8 +20,8 @@ public class Intake extends Command {
       new LoggedTunableNumber("Commands/Intake/OverCurrentThreshold", 14);
   private static final LoggedTunableNumber currentElapsedTime =
       new LoggedTunableNumber("Commands/Intake/OverCurrentTime", 0.04);
-  private static final LoggedTunableNumber sensorElapsedTime = new LoggedTunableNumber(
-      "Commands/Intake/SensorElapsedTime", 0.04);
+  private static final LoggedTunableNumber sensorElapsedTime =
+      new LoggedTunableNumber("Commands/Intake/SensorElapsedTime", 0.04);
   private static final LoggedTunableNumber spinupTime =
       new LoggedTunableNumber("Commands/Intake/SpinupTime", 0.15);
 
@@ -47,7 +47,8 @@ public class Intake extends Command {
     // TODO: Add a check to make sure elevator is down before fully intaking? Additional state.
     var detectionMode = robot.getFlywheelDetectionMode();
     var isCoralDetected =
-        detectionMode == DetectionMode.DISTANCE_SENSOR ? robot.getFlywheelSensorHold()
+        detectionMode == DetectionMode.DISTANCE_SENSOR
+            ? robot.getFlywheelSensorHold()
             : robot.getFlywheelCurrentHold(currentThreshold.get());
 
     if (timer.hasElapsed(spinupTime.get())) {
@@ -55,9 +56,11 @@ public class Intake extends Command {
         startingDetectionTimestamp = timer.get();
       }
 
-      if (isCoralDetected && timer.get() - startingDetectionTimestamp > (
-          detectionMode == DetectionMode.DISTANCE_SENSOR ? sensorElapsedTime.get()
-              : currentElapsedTime.get())) {
+      if (isCoralDetected
+          && timer.get() - startingDetectionTimestamp
+              > (detectionMode == DetectionMode.DISTANCE_SENSOR
+                  ? sensorElapsedTime.get()
+                  : currentElapsedTime.get())) {
         endCommand = true;
         robot.setState(OdysseusState.IDLE);
       } else {

--- a/src/main/java/com/team1165/robot/commands/RobotCommands.java
+++ b/src/main/java/com/team1165/robot/commands/RobotCommands.java
@@ -69,10 +69,7 @@ public class RobotCommands {
                       default -> OdysseusState.IDLE;
                     })
             .alongWith(
-                new WaitUntilCommand(
-                    () ->
-                        robot.getFlywheelCurrent() > 0
-                            && robot.getFlywheelCurrent() < scoreEndCurrent.get()))
+                new WaitUntilCommand(() -> robot.getFlywheelCurrentHold(scoreEndCurrent.get())))
             .andThen(
                 robot.stateSupplierCommand(
                     () ->

--- a/src/main/java/com/team1165/robot/commands/RobotCommands.java
+++ b/src/main/java/com/team1165/robot/commands/RobotCommands.java
@@ -69,7 +69,7 @@ public class RobotCommands {
                       default -> OdysseusState.IDLE;
                     })
             .alongWith(
-                new WaitUntilCommand(() -> robot.getFlywheelCurrentHold(scoreEndCurrent.get())))
+                new WaitUntilCommand(() -> robot.getFlywheelCurrent() > 0 && robot.getFlywheelCurrent() < scoreEndCurrent.get()))
             .andThen(
                 robot.stateSupplierCommand(
                     () ->

--- a/src/main/java/com/team1165/robot/globalconstants/CANConstants.java
+++ b/src/main/java/com/team1165/robot/globalconstants/CANConstants.java
@@ -18,6 +18,7 @@ public class CANConstants {
       public static final int flywheelSecondary = 2;
       public static final int funnelPrimary = 3;
       public static final int funnelSecondary = 4;
+      public static final int flywheelSensor = 5;
     }
 
     public static final class CANivore {

--- a/src/main/java/com/team1165/robot/globalconstants/Constants.java
+++ b/src/main/java/com/team1165/robot/globalconstants/Constants.java
@@ -11,5 +11,5 @@ package com.team1165.robot.globalconstants;
  * Global robot constants, typically ones that distinguish major functionality changes in the code.
  */
 public class Constants {
-  public static final boolean tuningMode = false;
+  public static final boolean tuningMode = true;
 }

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/Flywheel.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/Flywheel.java
@@ -31,7 +31,7 @@ public class Flywheel extends OverridableStateMachine<FlywheelState> {
   private final SensorIO sensorIO;
   private final SensorIOInputsAutoLogged sensorInputs = new SensorIOInputsAutoLogged();
   private final LoggedTunableNumber sensorDistanceThreshold =
-      new LoggedTunableNumber(name + "/Sensor/DistanceThreshold", 1.0);
+      new LoggedTunableNumber(name + "/Sensor/DistanceThreshold", 0.07);
   private DetectionMode detectionMode = FlywheelConstants.defaultDetectionMode;
   private final Alert sensorAlert =
       new Alert("Scoring mechanism sensor disconnected!", AlertType.kError);
@@ -50,8 +50,8 @@ public class Flywheel extends OverridableStateMachine<FlywheelState> {
     return detectionMode;
   }
 
-  public boolean getCurrentHold(double current) {
-    return Math.abs(inputs.primaryMotor.outputCurrentAmps) > current;
+  public double getCurrent() {
+    return inputs.primaryMotor.supplyCurrentAmps;
   }
 
   @AutoLogOutput(key = "Flywheel/Sensors/Hold")

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/Flywheel.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/Flywheel.java
@@ -7,6 +7,8 @@
 
 package com.team1165.robot.subsystems.roller.flywheel;
 
+import com.team1165.robot.subsystems.roller.flywheel.sensor.SensorIO;
+import com.team1165.robot.subsystems.roller.flywheel.sensor.SensorIO.SensorIOInputs;
 import com.team1165.robot.subsystems.roller.io.RollerIO;
 import com.team1165.robot.subsystems.roller.io.RollerIO.RollerIOInputs;
 import com.team1165.robot.util.logging.LoggedTunableNumber;
@@ -17,15 +19,21 @@ import org.littletonrobotics.junction.Logger;
 
 /** State-machine-based Flywheel subsystem, powered by two motors. */
 public class Flywheel extends OverridableStateMachine<FlywheelState> {
+  // RollerIO objects
   private final RollerIO io;
   private final RollerIOInputs inputs = new RollerIOInputs();
+
+  // SensorIO objects
+  private final SensorIO sensorIO;
+  private final SensorIOInputs sensorInputs = new SensorIOInputs();
 
   private final EnumMap<FlywheelState, LoggedTunableNumber> tunableMap =
       StateUtils.createTunableNumberMap(name + "/Voltages", FlywheelState.class);
 
-  public Flywheel(RollerIO io) {
+  public Flywheel(RollerIO io, SensorIO sensorIO) {
     super(FlywheelState.IDLE);
     this.io = io;
+    this.sensorIO = sensorIO;
   }
 
   public double getOutputCurrent() {
@@ -33,10 +41,16 @@ public class Flywheel extends OverridableStateMachine<FlywheelState> {
     return inputs.primaryMotor.outputCurrentAmps;
   }
 
+  public double getSensorDistance() {
+    return sensorInputs.distance;
+  }
+
   @Override
   protected void update() {
     io.updateInputs(inputs);
+    sensorIO.updateInputs(sensorInputs);
     Logger.processInputs(name, inputs);
+    Logger.processInputs(name + "/Sensor", inputs);
   }
 
   @Override

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/Flywheel.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/Flywheel.java
@@ -9,7 +9,6 @@ package com.team1165.robot.subsystems.roller.flywheel;
 
 import com.team1165.robot.subsystems.roller.flywheel.sensor.DetectionMode;
 import com.team1165.robot.subsystems.roller.flywheel.sensor.SensorIO;
-import com.team1165.robot.subsystems.roller.flywheel.sensor.SensorIO.SensorIOInputs;
 import com.team1165.robot.subsystems.roller.flywheel.sensor.SensorIOInputsAutoLogged;
 import com.team1165.robot.subsystems.roller.io.RollerIO;
 import com.team1165.robot.subsystems.roller.io.RollerIO.RollerIOInputs;
@@ -34,7 +33,8 @@ public class Flywheel extends OverridableStateMachine<FlywheelState> {
   private final LoggedTunableNumber sensorDistanceThreshold =
       new LoggedTunableNumber(name + "/Sensor/DistanceThreshold", 1.0);
   private DetectionMode detectionMode = FlywheelConstants.defaultDetectionMode;
-  private final Alert sensorAlert = new Alert("Scoring mechanism sensor disconnected!", AlertType.kError);
+  private final Alert sensorAlert =
+      new Alert("Scoring mechanism sensor disconnected!", AlertType.kError);
 
   private final EnumMap<FlywheelState, LoggedTunableNumber> tunableMap =
       StateUtils.createTunableNumberMap(name + "/Voltages", FlywheelState.class);
@@ -57,7 +57,8 @@ public class Flywheel extends OverridableStateMachine<FlywheelState> {
   @AutoLogOutput(key = "Flywheel/Sensors/Hold")
   public boolean getSensorHold() {
     // Default to true if the distance sensor is not active
-    return detectionMode != DetectionMode.DISTANCE_SENSOR || sensorInputs.distance < sensorDistanceThreshold.get();
+    return detectionMode != DetectionMode.DISTANCE_SENSOR
+        || sensorInputs.distance < sensorDistanceThreshold.get();
   }
 
   @Override
@@ -69,7 +70,8 @@ public class Flywheel extends OverridableStateMachine<FlywheelState> {
 
     // Detect if the CANrange has become disconnected and fall back to current
     if (FlywheelConstants.defaultDetectionMode != DetectionMode.CURRENT) {
-      detectionMode = sensorInputs.connected ? DetectionMode.DISTANCE_SENSOR : DetectionMode.CURRENT;
+      detectionMode =
+          sensorInputs.connected ? DetectionMode.DISTANCE_SENSOR : DetectionMode.CURRENT;
       sensorAlert.set(!sensorInputs.connected);
     }
   }

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/Flywheel.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/Flywheel.java
@@ -7,6 +7,7 @@
 
 package com.team1165.robot.subsystems.roller.flywheel;
 
+import com.team1165.robot.subsystems.roller.flywheel.sensor.DetectionMode;
 import com.team1165.robot.subsystems.roller.flywheel.sensor.SensorIO;
 import com.team1165.robot.subsystems.roller.flywheel.sensor.SensorIO.SensorIOInputs;
 import com.team1165.robot.subsystems.roller.io.RollerIO;
@@ -23,9 +24,10 @@ public class Flywheel extends OverridableStateMachine<FlywheelState> {
   private final RollerIO io;
   private final RollerIOInputs inputs = new RollerIOInputs();
 
-  // SensorIO objects
+  // Sensor objects
   private final SensorIO sensorIO;
   private final SensorIOInputs sensorInputs = new SensorIOInputs();
+  private DetectionMode detectionMode = FlywheelConstants.defaultDetectionMode;
 
   private final EnumMap<FlywheelState, LoggedTunableNumber> tunableMap =
       StateUtils.createTunableNumberMap(name + "/Voltages", FlywheelState.class);

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/FlywheelConstants.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/FlywheelConstants.java
@@ -46,5 +46,5 @@ public class FlywheelConstants {
   public static final CANrangeConfiguration baseSensorConfig = new CANrangeConfiguration();
   public static final CANrangeConfig sensorConfig = new CANrangeConfig("FlywheelSensor", RIO.flywheelSensor, "rio", baseSensorConfig);
 
-  public static final DetectionMode defaultDetectionMode = DetectionMode.DistanceSensor;
+  public static final DetectionMode defaultDetectionMode = DetectionMode.DISTANCE_SENSOR;
 }

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/FlywheelConstants.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/FlywheelConstants.java
@@ -10,11 +10,13 @@ package com.team1165.robot.subsystems.roller.flywheel;
 import static edu.wpi.first.units.Units.KilogramSquareMeters;
 import static edu.wpi.first.units.Units.Volts;
 
+import com.ctre.phoenix6.configs.CANrangeConfiguration;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
 import com.revrobotics.spark.config.SparkBaseConfig;
 import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
 import com.revrobotics.spark.config.SparkMaxConfig;
 import com.team1165.robot.globalconstants.CANConstants.IDs.RIO;
+import com.team1165.robot.util.vendor.ctre.PhoenixDeviceConfigs.CANrangeConfig;
 import com.team1165.robot.util.vendor.rev.SparkConfig;
 import edu.wpi.first.math.system.plant.DCMotor;
 import org.ironmaple.simulation.motorsims.SimMotorConfigs;
@@ -38,4 +40,8 @@ public class FlywheelConstants {
   // Simulation motor configuration
   public static final SimMotorConfigs simConfig =
       new SimMotorConfigs(DCMotor.getNEO(1), 1, KilogramSquareMeters.of(0.002), Volts.of(0.05));
+
+  // Sensor configuration
+  public static final CANrangeConfiguration baseSensorConfig = new CANrangeConfiguration();
+  public static final CANrangeConfig sensorConfig = new CANrangeConfig("FlywheelSensor", RIO.flywheelSensor, "rio", baseSensorConfig);
 }

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/FlywheelConstants.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/FlywheelConstants.java
@@ -16,6 +16,7 @@ import com.revrobotics.spark.config.SparkBaseConfig;
 import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
 import com.revrobotics.spark.config.SparkMaxConfig;
 import com.team1165.robot.globalconstants.CANConstants.IDs.RIO;
+import com.team1165.robot.subsystems.roller.flywheel.sensor.DetectionMode;
 import com.team1165.robot.util.vendor.ctre.PhoenixDeviceConfigs.CANrangeConfig;
 import com.team1165.robot.util.vendor.rev.SparkConfig;
 import edu.wpi.first.math.system.plant.DCMotor;
@@ -44,4 +45,6 @@ public class FlywheelConstants {
   // Sensor configuration
   public static final CANrangeConfiguration baseSensorConfig = new CANrangeConfiguration();
   public static final CANrangeConfig sensorConfig = new CANrangeConfig("FlywheelSensor", RIO.flywheelSensor, "rio", baseSensorConfig);
+
+  public static final DetectionMode defaultDetectionMode = DetectionMode.DistanceSensor;
 }

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/FlywheelConstants.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/FlywheelConstants.java
@@ -11,6 +11,7 @@ import static edu.wpi.first.units.Units.KilogramSquareMeters;
 import static edu.wpi.first.units.Units.Volts;
 
 import com.ctre.phoenix6.configs.CANrangeConfiguration;
+import com.ctre.phoenix6.signals.UpdateModeValue;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
 import com.revrobotics.spark.config.SparkBaseConfig;
 import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
@@ -48,4 +49,11 @@ public class FlywheelConstants {
       new CANrangeConfig("FlywheelSensor", RIO.flywheelSensor, "rio", baseSensorConfig);
 
   public static final DetectionMode defaultDetectionMode = DetectionMode.DISTANCE_SENSOR;
+
+  static {
+    baseSensorConfig.ToFParams.UpdateMode = UpdateModeValue.ShortRange100Hz;
+
+    baseSensorConfig.FovParams.FOVRangeX = 10;
+    baseSensorConfig.FovParams.FOVRangeY = 10;
+  }
 }

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/FlywheelConstants.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/FlywheelConstants.java
@@ -44,7 +44,8 @@ public class FlywheelConstants {
 
   // Sensor configuration
   public static final CANrangeConfiguration baseSensorConfig = new CANrangeConfiguration();
-  public static final CANrangeConfig sensorConfig = new CANrangeConfig("FlywheelSensor", RIO.flywheelSensor, "rio", baseSensorConfig);
+  public static final CANrangeConfig sensorConfig =
+      new CANrangeConfig("FlywheelSensor", RIO.flywheelSensor, "rio", baseSensorConfig);
 
   public static final DetectionMode defaultDetectionMode = DetectionMode.DISTANCE_SENSOR;
 }

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/DetectionMode.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/DetectionMode.java
@@ -9,7 +9,7 @@ package com.team1165.robot.subsystems.roller.flywheel.sensor;
 
 public enum DetectionMode {
   /** Detection using current, only works if the wheels are actively spinning. */
-  Current,
+  CURRENT,
   /** Detection using a distance sensor, like a CANrange. */
-  DistanceSensor
+  DISTANCE_SENSOR
 }

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/DetectionMode.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/DetectionMode.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Team Paradise - FRC 1165 (https://github.com/TeamParadise)
+ *
+ * Use of this source code is governed by the MIT License, which can be found in the LICENSE file at
+ * the root directory of this project.
+ */
+
+package com.team1165.robot.subsystems.roller.flywheel.sensor;
+
+public enum DetectionMode {
+  /** Detection using current, only works if the wheels are actively spinning. */
+  Current,
+  /** Detection using a distance sensor, like a CANrange. */
+  DistanceSensor
+}

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIO.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIO.java
@@ -14,6 +14,7 @@ public interface SensorIO {
   /** Class used to store the IO values of a sensor. */
   @AutoLog
   class SensorIOInputs {
+    public boolean connected = false;
     public double distance = 0.0;
   }
 

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIO.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIO.java
@@ -9,7 +9,10 @@ package com.team1165.robot.subsystems.roller.flywheel.sensor;
 
 import org.littletonrobotics.junction.AutoLog;
 
-/** A hardware interface/implementation layer for a sensor (beam break/distance sensor style) for the {@link com.team1165.robot.subsystems.roller.flywheel.Flywheel} subsystem. */
+/**
+ * A hardware interface/implementation layer for a sensor (beam break/distance sensor style) for the
+ * {@link com.team1165.robot.subsystems.roller.flywheel.Flywheel} subsystem.
+ */
 public interface SensorIO {
   /** Class used to store the IO values of a sensor. */
   @AutoLog

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIO.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIO.java
@@ -1,4 +1,26 @@
+/*
+ * Copyright (c) 2025 Team Paradise - FRC 1165 (https://github.com/TeamParadise)
+ *
+ * Use of this source code is governed by the MIT License, which can be found in the LICENSE file at
+ * the root directory of this project.
+ */
+
 package com.team1165.robot.subsystems.roller.flywheel.sensor;
 
+import org.littletonrobotics.junction.AutoLog;
+
+/** A hardware interface/implementation layer for a sensor (beam break/distance sensor style) for the {@link com.team1165.robot.subsystems.roller.flywheel.Flywheel} subsystem. */
 public interface SensorIO {
+  /** Class used to store the IO values of a sensor. */
+  @AutoLog
+  class SensorIOInputs {
+    public double distance = 0.0;
+  }
+
+  /**
+   * Updates a {@link SensorIOInputs} instance with the latest updates from this {@link SensorIO}.
+   *
+   * @param inputs A {@link SensorIOInputs} instance to update.
+   */
+  default void updateInputs(SensorIOInputs inputs) {}
 }

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIO.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIO.java
@@ -1,0 +1,4 @@
+package com.team1165.robot.subsystems.roller.flywheel.sensor;
+
+public interface SensorIO {
+}

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIOCTRE.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIOCTRE.java
@@ -23,6 +23,7 @@ public class SensorIOCTRE implements SensorIO {
     PhoenixUtil.registerSignals(config.canBus(), sensor.getDistance());
   }
 
+  @Override
   public void updateInputs(SensorIOInputs inputs) {
     inputs.connected = sensor.isConnected();
     inputs.distance = sensor.getDistance(false).getValueAsDouble();

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIOCTRE.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIOCTRE.java
@@ -8,14 +8,13 @@
 package com.team1165.robot.subsystems.roller.flywheel.sensor;
 
 import com.ctre.phoenix6.hardware.CANrange;
-import com.team1165.robot.subsystems.roller.flywheel.sensor.SensorIO.SensorIOInputs;
 import com.team1165.robot.util.vendor.ctre.PhoenixDeviceConfigs.CANrangeConfig;
 import com.team1165.robot.util.vendor.ctre.PhoenixUtil;
 
 /**
  * A hardware interface/implementation layer for a CTRE CANrange sensor.
  */
-public class SensorIOCTRE {
+public class SensorIOCTRE implements SensorIO{
   private final CANrange sensor;
 
   public SensorIOCTRE(CANrangeConfig config) {

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIOCTRE.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIOCTRE.java
@@ -21,9 +21,13 @@ public class SensorIOCTRE {
   public SensorIOCTRE(CANrangeConfig config) {
     // Initialize CANrange
     sensor = PhoenixUtil.createNewCANrange(config);
+
+    // Add values to Phoenix refresh
+    PhoenixUtil.registerSignals(config.canBus(), sensor.getDistance());
   }
 
   public void updateInputs(SensorIOInputs inputs) {
-    inputs.distance = sensor.getDistance().getValueAsDouble();
+    inputs.connected = sensor.isConnected();
+    inputs.distance = sensor.getDistance(false).getValueAsDouble();
   }
 }

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIOCTRE.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIOCTRE.java
@@ -11,10 +11,8 @@ import com.ctre.phoenix6.hardware.CANrange;
 import com.team1165.robot.util.vendor.ctre.PhoenixDeviceConfigs.CANrangeConfig;
 import com.team1165.robot.util.vendor.ctre.PhoenixUtil;
 
-/**
- * A hardware interface/implementation layer for a CTRE CANrange sensor.
- */
-public class SensorIOCTRE implements SensorIO{
+/** A hardware interface/implementation layer for a CTRE CANrange sensor. */
+public class SensorIOCTRE implements SensorIO {
   private final CANrange sensor;
 
   public SensorIOCTRE(CANrangeConfig config) {

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIOCTRE.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIOCTRE.java
@@ -1,0 +1,4 @@
+package com.team1165.robot.subsystems.roller.flywheel.sensor;
+
+public class SensorIOCANrange {
+}

--- a/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIOCTRE.java
+++ b/src/main/java/com/team1165/robot/subsystems/roller/flywheel/sensor/SensorIOCTRE.java
@@ -1,4 +1,29 @@
+/*
+ * Copyright (c) 2025 Team Paradise - FRC 1165 (https://github.com/TeamParadise)
+ *
+ * Use of this source code is governed by the MIT License, which can be found in the LICENSE file at
+ * the root directory of this project.
+ */
+
 package com.team1165.robot.subsystems.roller.flywheel.sensor;
 
-public class SensorIOCANrange {
+import com.ctre.phoenix6.hardware.CANrange;
+import com.team1165.robot.subsystems.roller.flywheel.sensor.SensorIO.SensorIOInputs;
+import com.team1165.robot.util.vendor.ctre.PhoenixDeviceConfigs.CANrangeConfig;
+import com.team1165.robot.util.vendor.ctre.PhoenixUtil;
+
+/**
+ * A hardware interface/implementation layer for a CTRE CANrange sensor.
+ */
+public class SensorIOCTRE {
+  private final CANrange sensor;
+
+  public SensorIOCTRE(CANrangeConfig config) {
+    // Initialize CANrange
+    sensor = PhoenixUtil.createNewCANrange(config);
+  }
+
+  public void updateInputs(SensorIOInputs inputs) {
+    inputs.distance = sensor.getDistance().getValueAsDouble();
+  }
 }


### PR DESCRIPTION
Add CANrange support for the scoring mechanism instead of relying solely on current. Resolves #37.

Things to be tested before merging into develop

- Tune intake timing with the CANrange
- Test adjusting default detection mode in FlywheelConstants
- Test to make sure current sensing with the intake and scoring still works
- Test automatic switching between CANrange and current if anything goes wrong