### PR TITLE
Add vision state machine

### DIFF
--- a/src/main/java/com/team1165/robot/OdysseusManager.java
+++ b/src/main/java/com/team1165/robot/OdysseusManager.java
@@ -13,6 +13,8 @@ import com.team1165.robot.subsystems.roller.flywheel.Flywheel;
 import com.team1165.robot.subsystems.roller.flywheel.FlywheelState;
 import com.team1165.robot.subsystems.roller.funnel.Funnel;
 import com.team1165.robot.subsystems.roller.funnel.FunnelState;
+import com.team1165.robot.subsystems.vision.apriltag.ATVision;
+import com.team1165.robot.subsystems.vision.apriltag.ATVisionState;
 import com.team1165.robot.util.statemachine.RobotManager;
 import com.team1165.robot.util.statemachine.StateMachine;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -20,6 +22,7 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import java.util.function.Supplier;
 
 public class OdysseusManager extends RobotManager<OdysseusState> {
+  private final ATVision apriltagVision;
   private final Elevator elevator;
   private final Flywheel flywheel;
   private final Funnel funnel;
@@ -31,8 +34,13 @@ public class OdysseusManager extends RobotManager<OdysseusState> {
    * @see StateMachine
    */
   protected OdysseusManager(
-      OdysseusState initialState, Elevator elevator, Flywheel flywheel, Funnel funnel) {
+      OdysseusState initialState,
+      ATVision apriltagVision,
+      Elevator elevator,
+      Flywheel flywheel,
+      Funnel funnel) {
     super(initialState);
+    this.apriltagVision = apriltagVision;
     this.elevator = elevator;
     this.flywheel = flywheel;
     this.funnel = funnel;
@@ -65,76 +73,91 @@ public class OdysseusManager extends RobotManager<OdysseusState> {
         // TODO: Maybe add a method to ElevatorState to get the specified state for a specific reef
         // TODO: level, to prevent having to copy and paste code over and over?
       case IDLE -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_TRIG);
         setSubsystemState(elevator, ElevatorState.IDLE);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.IDLE);
       }
       case INTAKE -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_TRIG);
         setSubsystemState(elevator, ElevatorState.INTAKE);
         setSubsystemState(funnel, FunnelState.INTAKE);
         setSubsystemState(flywheel, FlywheelState.INTAKE);
       }
       case L1 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L1);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.IDLE);
       }
       case SCORE_L1 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L1);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.SLOW_SCORE);
       }
       case FAST_SCORE_L1 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L1);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.FAST_SCORE);
       }
       case L2 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L2);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.IDLE);
       }
       case SCORE_L2 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L2);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.SLOW_SCORE);
       }
       case FAST_SCORE_L2 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L2);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.FAST_SCORE);
       }
       case L3 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L3);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.IDLE);
       }
       case SCORE_L3 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L3);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.SLOW_SCORE);
       }
       case FAST_SCORE_L3 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L3);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.FAST_SCORE);
       }
       case L4 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L4);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.IDLE);
       }
       case SCORE_L4 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L4);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.SLOW_SCORE);
       }
       case FAST_SCORE_L4 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L4);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.FAST_SCORE);
       }
       case ZERO_ELEVATOR -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_TRIG);
         setSubsystemState(elevator, ElevatorState.ZEROING);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.IDLE);

--- a/src/main/java/com/team1165/robot/RobotContainer.java
+++ b/src/main/java/com/team1165/robot/RobotContainer.java
@@ -54,6 +54,7 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import edu.wpi.first.wpilibj2.command.button.RobotModeTriggers;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a

--- a/src/main/java/com/team1165/robot/RobotContainer.java
+++ b/src/main/java/com/team1165/robot/RobotContainer.java
@@ -54,7 +54,6 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
-import edu.wpi.first.wpilibj2.command.button.RobotModeTriggers;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -182,7 +181,7 @@ public class RobotContainer {
       }
     }
 
-    robot = new OdysseusManager(OdysseusState.IDLE, elevator, flywheel, funnel);
+    robot = new OdysseusManager(OdysseusState.IDLE, apriltagVision, elevator, flywheel, funnel);
 
     autoBuilder = AutoBuilder.getInstance();
 

--- a/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVision.java
+++ b/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVision.java
@@ -28,7 +28,7 @@ import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Alert.AlertType;
 import edu.wpi.first.wpilibj.Timer;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj2.command.Command;
 import java.util.ArrayDeque;
 import java.util.Queue;
 import org.littletonrobotics.junction.Logger;
@@ -63,6 +63,9 @@ public class ATVision extends OverridableStateMachine<ATVisionState> {
       ATVisionConsumer globalConsumer,
       ATVisionRotationSupplier robotRotationSupplier,
       CameraConfig... config) {
+    // Call super from state machine
+    super(ATVisionState.SINGLE_TAG_3D);
+
     // Initialize consumer and supplier
     this.globalConsumer = globalConsumer;
     rotationSupplier = robotRotationSupplier;
@@ -91,6 +94,9 @@ public class ATVision extends OverridableStateMachine<ATVisionState> {
               "The AprilTag camera \"" + inputs[i].name + "\" (ID " + i + ") is disconnected.",
               AlertType.kWarning);
     }
+
+    // Specifically make sure we are set to SINGLE_TAG_3D before enabled for pose correction
+    setState(ATVisionState.SINGLE_TAG_3D);
   }
 
   @Override
@@ -323,9 +329,21 @@ public class ATVision extends OverridableStateMachine<ATVisionState> {
         "AprilTagVision/Summary/RobotPosesRejected", allRobotPosesRejected.toArray(new Pose3d[0]));
   }
 
-  public void enableSingleTagTrig() {
+  @Override
+  public Command overrideState(ATVisionState state) {
+    return super.overrideState(state).ignoringDisable(true);
+  }
+
+  private void setSingleTagTrig(boolean enable) {
     for (ATVisionIO visionIO : io) {
-      visionIO.setSingleTagTrig(true);
+      visionIO.setSingleTagTrig(enable);
+    }
+  }
+
+  protected void transition() {
+    switch (getCurrentState()) {
+      case SINGLE_TAG_3D -> setSingleTagTrig(false);
+      case SINGLE_TAG_TRIG -> setSingleTagTrig(true);
     }
   }
 

--- a/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVision.java
+++ b/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVision.java
@@ -12,6 +12,7 @@ import static com.team1165.robot.subsystems.vision.apriltag.constants.ATVisionCo
 import com.ctre.phoenix6.Utils;
 import com.team1165.robot.subsystems.vision.apriltag.io.ATVisionIO;
 import com.team1165.robot.subsystems.vision.apriltag.io.ATVisionIOInputsAutoLogged;
+import com.team1165.robot.util.statemachine.OverridableStateMachine;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -36,7 +37,7 @@ import org.littletonrobotics.junction.Logger;
  * A subsystem for a collection of cameras that estimates the pose of the robot with AprilTags
  * placed around the field.
  */
-public class ATVision extends SubsystemBase {
+public class ATVision extends OverridableStateMachine<ATVisionState> {
   // Alerts to send for each of the cameras if they get disconnected
   private final Alert[] disconnectedAlerts;
 
@@ -323,8 +324,8 @@ public class ATVision extends SubsystemBase {
   }
 
   public void enableSingleTagTrig() {
-    for (int i = 0; i < io.length; i++) {
-      io[i].setSingleTagTrig(true);
+    for (ATVisionIO visionIO : io) {
+      visionIO.setSingleTagTrig(true);
     }
   }
 

--- a/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVisionState.java
+++ b/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVisionState.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Team Paradise - FRC 1165 (https://github.com/TeamParadise)
+ *
+ * Use of this source code is governed by the MIT License, which can be found in the LICENSE file at
+ * the root directory of this project.
+ */
+
+package com.team1165.robot.subsystems.vision.apriltag;
+
+import com.team1165.robot.util.statemachine.State;
+
+/** All the possible states for the {@link ATVision} subsystem. */
+public enum ATVisionState implements State {
+  /** Single-tag vision without the trig-based gyro combination. Default PhotonVision method, more accurate up-close, less accurate when far away. */
+  SINGLE_TAG_3D(),
+  /** Single-tag vision with the trig-based gyro combination. More accurate further away, less accurate close up. */
+  SINGLE_TAG_TRIG()
+}

--- a/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVisionState.java
+++ b/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVisionState.java
@@ -11,8 +11,14 @@ import com.team1165.robot.util.statemachine.State;
 
 /** All the possible states for the {@link ATVision} subsystem. */
 public enum ATVisionState implements State {
-  /** Single-tag vision without the trig-based gyro combination. Default PhotonVision method, more accurate up-close, less accurate when far away. */
+  /**
+   * Single-tag vision without the trig-based gyro combination. Default PhotonVision method, more
+   * accurate up-close, less accurate when far away.
+   */
   SINGLE_TAG_3D(),
-  /** Single-tag vision with the trig-based gyro combination. More accurate further away, less accurate close up. */
+  /**
+   * Single-tag vision with the trig-based gyro combination. More accurate further away, less
+   * accurate close up.
+   */
   SINGLE_TAG_TRIG()
 }

--- a/src/main/java/com/team1165/robot/util/statemachine/State.java
+++ b/src/main/java/com/team1165/robot/util/statemachine/State.java
@@ -18,5 +18,6 @@ import java.util.OptionalDouble;
 public interface State {
   default OptionalDouble get() {
     return OptionalDouble.empty();
-  };
+  }
+  ;
 }

--- a/src/main/java/com/team1165/robot/util/statemachine/State.java
+++ b/src/main/java/com/team1165/robot/util/statemachine/State.java
@@ -16,5 +16,7 @@ import java.util.OptionalDouble;
  * represents a distinct state that the {@link StateMachine} can be in.
  */
 public interface State {
-  OptionalDouble get();
+  default OptionalDouble get() {
+    return OptionalDouble.empty();
+  };
 }


### PR DESCRIPTION
Add a vision state machine in order to switch between single tag 3D and trig based pose estimation depending on whether we are just driving/intaking or actually scoring. Resolves #33.

Just needs to be tested on the actual robot, also, I should probably fix rejection of the barge tags, as I don't think my code for rejecting them right now is actually working.