### PR TITLE
Add buttons for automatically lining up to closest left/right branch

### DIFF
--- a/src/main/java/com/team1165/robot/RobotContainer.java
+++ b/src/main/java/com/team1165/robot/RobotContainer.java
@@ -217,8 +217,16 @@ public class RobotContainer {
         .onTrue(
             RobotCommands.moveDownLevel(robot)
                 .withName("Controller - D-Pad Down - Move Down One Level"));
-    driverController.povLeft().whileTrue(RobotCommands.autoAlignToNearest(drive, true).withName("Controller - D-Pad Left - Align To Left Branch"));
-    driverController.povRight().whileTrue(RobotCommands.autoAlignToNearest(drive, false).withName("Controller - D-Pad Right - Align To Right Branch"));
+    driverController
+        .povLeft()
+        .whileTrue(
+            RobotCommands.autoAlignToNearest(drive, true)
+                .withName("Controller - D-Pad Left - Align To Left Branch"));
+    driverController
+        .povRight()
+        .whileTrue(
+            RobotCommands.autoAlignToNearest(drive, false)
+                .withName("Controller - D-Pad Right - Align To Right Branch"));
 
     // Bumpers
     driverController

--- a/src/main/java/com/team1165/robot/commands/RobotCommands.java
+++ b/src/main/java/com/team1165/robot/commands/RobotCommands.java
@@ -15,9 +15,7 @@ import com.team1165.robot.globalconstants.FieldConstants.Reef;
 import com.team1165.robot.globalconstants.FieldConstants.Reef.Level;
 import com.team1165.robot.subsystems.drive.Drive;
 import com.team1165.robot.subsystems.elevator.Elevator;
-import com.team1165.robot.subsystems.vision.apriltag.constants.ATVisionConstants;
 import com.team1165.robot.util.logging.LoggedTunableNumber;
-import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.math.filter.Debouncer;
 import edu.wpi.first.math.filter.Debouncer.DebounceType;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -161,12 +159,12 @@ public class RobotCommands {
         .andThen(
             driveCloseToFaceStart.raceWith(
                 new WaitUntilCommand(
-                    () ->
-                        drive
-                            .getPose()
-                            .getTranslation()
-                            .getDistance(face.get().getPose().getTranslation())
-                            < autoScoreElevatorRaiseDistance.get())
+                        () ->
+                            drive
+                                    .getPose()
+                                    .getTranslation()
+                                    .getDistance(face.get().getPose().getTranslation())
+                                < autoScoreElevatorRaiseDistance.get())
                     .andThen(switchToHeight)))
         .andThen(
             driveCloseToFaceStart2.until(
@@ -176,15 +174,15 @@ public class RobotCommands {
         .andThen(
             driveToFace.withDeadline(
                 new WaitUntilCommand(
-                    () ->
-                        debouncer.calculate(
-                            drive
-                                .getPose()
-                                .getTranslation()
-                                .getDistance(face.get().getPose().getTranslation())
-                                < autoScoreDistanceToleranceBeforeScore.get())
-                            && robot.getElevatorAtGoal(
-                            autoScoreElevatorToleranceBeforeScore.get()))
+                        () ->
+                            debouncer.calculate(
+                                    drive
+                                            .getPose()
+                                            .getTranslation()
+                                            .getDistance(face.get().getPose().getTranslation())
+                                        < autoScoreDistanceToleranceBeforeScore.get())
+                                && robot.getElevatorAtGoal(
+                                    autoScoreElevatorToleranceBeforeScore.get()))
                     .andThen(score(robot, false, 0.35))))
         .andThen(
             new ConditionalCommand(
@@ -203,21 +201,28 @@ public class RobotCommands {
 
   // region Auto Align
   public static Command autoAlignToNearest(Drive drive, boolean left) {
-    return Commands.defer(() -> {
-      Pose2d closestAprilTag = drive.getPose().nearest(FieldConstants.reefAprilTagPoses);
-      int closestID = FieldConstants.reefAprilTagIDs.get(
-          FieldConstants.reefAprilTagPoses.indexOf(closestAprilTag));
+    return Commands.defer(
+        () -> {
+          Pose2d closestAprilTag = drive.getPose().nearest(FieldConstants.reefAprilTagPoses);
+          int closestID =
+              FieldConstants.reefAprilTagIDs.get(
+                  FieldConstants.reefAprilTagPoses.indexOf(closestAprilTag));
 
-      return new DriveToPose(drive, () -> switch (closestID) {
-        case 7, 18 -> left ? Reef.Location.A.getPose() : Reef.Location.B.getPose();
-        case 8, 17 -> left ? Reef.Location.C.getPose() : Reef.Location.D.getPose();
-        case 9, 22 -> left ? Reef.Location.E.getPose() : Reef.Location.F.getPose();
-        case 10, 21 -> left ? Reef.Location.G.getPose() : Reef.Location.H.getPose();
-        case 11, 20 -> left ? Reef.Location.I.getPose() : Reef.Location.J.getPose();
-        default -> left ? Reef.Location.K.getPose() : Reef.Location.L.getPose();
-      });
-    }, Set.of(drive));
+          return new DriveToPose(
+              drive,
+              () ->
+                  switch (closestID) {
+                    case 7, 18 -> left ? Reef.Location.A.getPose() : Reef.Location.B.getPose();
+                    case 8, 17 -> left ? Reef.Location.C.getPose() : Reef.Location.D.getPose();
+                    case 9, 22 -> left ? Reef.Location.E.getPose() : Reef.Location.F.getPose();
+                    case 10, 21 -> left ? Reef.Location.G.getPose() : Reef.Location.H.getPose();
+                    case 11, 20 -> left ? Reef.Location.I.getPose() : Reef.Location.J.getPose();
+                    default -> left ? Reef.Location.K.getPose() : Reef.Location.L.getPose();
+                  });
+        },
+        Set.of(drive));
   }
+
   // endregion
 
   // endregion

--- a/src/main/java/com/team1165/robot/globalconstants/FieldConstants.java
+++ b/src/main/java/com/team1165/robot/globalconstants/FieldConstants.java
@@ -28,17 +28,17 @@ public class FieldConstants {
   public static final Distance startingLineX =
       Units.Inches.of(299.438); // Measured from the inside of starting line
 
-  public static final List<Integer> reefAprilTagIDs = List.of(6, 7, 8, 9, 10, 11, 17, 18, 19, 20, 21, 22);
-  public static final List<Pose2d> reefAprilTagPoses = ATVisionConstants.aprilTagLayout.getTags()
-      .stream()
-      .filter(tag -> reefAprilTagIDs.contains(tag.ID))
-      .map(tag -> tag.pose.toPose2d())
-      .toList();
+  public static final List<Integer> reefAprilTagIDs =
+      List.of(6, 7, 8, 9, 10, 11, 17, 18, 19, 20, 21, 22);
+  public static final List<Pose2d> reefAprilTagPoses =
+      ATVisionConstants.aprilTagLayout.getTags().stream()
+          .filter(tag -> reefAprilTagIDs.contains(tag.ID))
+          .map(tag -> tag.pose.toPose2d())
+          .toList();
+
   // endregion
 
-  /**
-   * Generic poses without any "fudge" factors or alliance switching.
-   */
+  /** Generic poses without any "fudge" factors or alliance switching. */
   private static class GenericPoses {
 
     private static final Pose2d reefA =
@@ -75,9 +75,7 @@ public class FieldConstants {
             Rotation2d.fromRadians(-rightCoralStation.getRotation().getRadians()));
   }
 
-  /**
-   * Elevator heights for scoring on the Reef.
-   */
+  /** Elevator heights for scoring on the Reef. */
   private static class ElevatorHeights {
 
     private static final double l1 = 2.0;
@@ -117,9 +115,7 @@ public class FieldConstants {
     private static final Transform2d leftCoralStation = new Transform2d(0.0, 0.0, Rotation2d.kZero);
   }
 
-  /**
-   * Alliance poses based off the generic poses combined with the fudge factors.
-   */
+  /** Alliance poses based off the generic poses combined with the fudge factors. */
   private static class AlliancePoses {
 
     private static class Blue {
@@ -193,9 +189,7 @@ public class FieldConstants {
     }
   }
 
-  /**
-   * Constants for Reef scoring and lineup.
-   */
+  /** Constants for Reef scoring and lineup. */
   public static final class Reef {
 
     public enum Level {
@@ -234,27 +228,23 @@ public class FieldConstants {
     }
   }
 
-  /**
-   * Simple enum to specify the coral station to score at.
-   */
+  /** Simple enum to specify the coral station to score at. */
   public enum CoralStationLocation {
-    /**
-     * The right coral station FROM THE DRIVER STATION PERSPECTIVE.
-     */
+    /** The right coral station FROM THE DRIVER STATION PERSPECTIVE. */
     RCS,
-    /**
-     * The left coral station FROM THE DRIVER STATION PERSPECTIVE.
-     */
+    /** The left coral station FROM THE DRIVER STATION PERSPECTIVE. */
     LCS;
 
     public Pose2d getPose() {
       return switch (this) {
-        case RCS -> AllianceFlipUtil.shouldFlip()
-            ? AlliancePoses.Red.rightCoralStation
-            : AlliancePoses.Blue.rightCoralStation;
-        case LCS -> AllianceFlipUtil.shouldFlip()
-            ? AlliancePoses.Red.leftCoralStation
-            : AlliancePoses.Blue.leftCoralStation;
+        case RCS ->
+            AllianceFlipUtil.shouldFlip()
+                ? AlliancePoses.Red.rightCoralStation
+                : AlliancePoses.Blue.rightCoralStation;
+        case LCS ->
+            AllianceFlipUtil.shouldFlip()
+                ? AlliancePoses.Red.leftCoralStation
+                : AlliancePoses.Blue.leftCoralStation;
       };
     }
   }


### PR DESCRIPTION
Add manual buttons for aligning to the closest left/right branch in case anything goes wrong with the dashboard. Resolve #36.

Tested in simulation and seems to work, and it doesn't affect any already existing functions of the robot (just adds buttons to the left and right d-pad), so it's safe to merge now.