### PR TITLE
Speed up auto/prevent slamming into coral station

### DIFF
--- a/src/main/java/com/team1165/robot/OdysseusManager.java
+++ b/src/main/java/com/team1165/robot/OdysseusManager.java
@@ -13,6 +13,8 @@ import com.team1165.robot.subsystems.roller.flywheel.Flywheel;
 import com.team1165.robot.subsystems.roller.flywheel.FlywheelState;
 import com.team1165.robot.subsystems.roller.funnel.Funnel;
 import com.team1165.robot.subsystems.roller.funnel.FunnelState;
+import com.team1165.robot.subsystems.vision.apriltag.ATVision;
+import com.team1165.robot.subsystems.vision.apriltag.ATVisionState;
 import com.team1165.robot.util.statemachine.RobotManager;
 import com.team1165.robot.util.statemachine.StateMachine;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -20,6 +22,7 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import java.util.function.Supplier;
 
 public class OdysseusManager extends RobotManager<OdysseusState> {
+  private final ATVision apriltagVision;
   private final Elevator elevator;
   private final Flywheel flywheel;
   private final Funnel funnel;
@@ -31,8 +34,13 @@ public class OdysseusManager extends RobotManager<OdysseusState> {
    * @see StateMachine
    */
   protected OdysseusManager(
-      OdysseusState initialState, Elevator elevator, Flywheel flywheel, Funnel funnel) {
+      OdysseusState initialState,
+      ATVision apriltagVision,
+      Elevator elevator,
+      Flywheel flywheel,
+      Funnel funnel) {
     super(initialState);
+    this.apriltagVision = apriltagVision;
     this.elevator = elevator;
     this.flywheel = flywheel;
     this.funnel = funnel;
@@ -65,76 +73,91 @@ public class OdysseusManager extends RobotManager<OdysseusState> {
         // TODO: Maybe add a method to ElevatorState to get the specified state for a specific reef
         // TODO: level, to prevent having to copy and paste code over and over?
       case IDLE -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_TRIG);
         setSubsystemState(elevator, ElevatorState.IDLE);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.IDLE);
       }
       case INTAKE -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_TRIG);
         setSubsystemState(elevator, ElevatorState.INTAKE);
         setSubsystemState(funnel, FunnelState.INTAKE);
         setSubsystemState(flywheel, FlywheelState.INTAKE);
       }
       case L1 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L1);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.IDLE);
       }
       case SCORE_L1 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L1);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.SLOW_SCORE);
       }
       case FAST_SCORE_L1 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L1);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.FAST_SCORE);
       }
       case L2 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L2);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.IDLE);
       }
       case SCORE_L2 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L2);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.SLOW_SCORE);
       }
       case FAST_SCORE_L2 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L2);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.FAST_SCORE);
       }
       case L3 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L3);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.IDLE);
       }
       case SCORE_L3 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L3);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.SLOW_SCORE);
       }
       case FAST_SCORE_L3 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L3);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.FAST_SCORE);
       }
       case L4 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L4);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.IDLE);
       }
       case SCORE_L4 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L4);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.SLOW_SCORE);
       }
       case FAST_SCORE_L4 -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_3D);
         setSubsystemState(elevator, ElevatorState.L4);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.FAST_SCORE);
       }
       case ZERO_ELEVATOR -> {
+        setSubsystemState(apriltagVision, ATVisionState.SINGLE_TAG_TRIG);
         setSubsystemState(elevator, ElevatorState.ZEROING);
         setSubsystemState(funnel, FunnelState.IDLE);
         setSubsystemState(flywheel, FlywheelState.IDLE);

--- a/src/main/java/com/team1165/robot/RobotContainer.java
+++ b/src/main/java/com/team1165/robot/RobotContainer.java
@@ -54,6 +54,7 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import edu.wpi.first.wpilibj2.command.button.RobotModeTriggers;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a

--- a/src/main/java/com/team1165/robot/RobotContainer.java
+++ b/src/main/java/com/team1165/robot/RobotContainer.java
@@ -54,7 +54,6 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
-import edu.wpi.first.wpilibj2.command.button.RobotModeTriggers;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -182,7 +181,7 @@ public class RobotContainer {
       }
     }
 
-    robot = new OdysseusManager(OdysseusState.IDLE, elevator, flywheel, funnel);
+    robot = new OdysseusManager(OdysseusState.IDLE, apriltagVision, elevator, flywheel, funnel);
 
     autoBuilder = AutoBuilder.getInstance();
 

--- a/src/main/java/com/team1165/robot/RobotContainer.java
+++ b/src/main/java/com/team1165/robot/RobotContainer.java
@@ -45,8 +45,12 @@ import com.team1165.robot.subsystems.vision.apriltag.io.ATVisionIOPhotonSim.ATVi
 import com.team1165.robot.util.TeleopDashboard;
 import com.team1165.robot.util.auto.AutoBuilder;
 import com.team1165.robot.util.constants.RobotMode;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Command.InterruptionBehavior;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
@@ -300,6 +304,15 @@ public class RobotContainer {
   }
 
   public Command getAutonomousCommand() {
-    return autoBuilder.getAutoCommand(drive);
+    return Commands.runOnce(
+            () ->
+                drive.resetPose(
+                    new Pose2d(
+                        drive.getPose().getTranslation(),
+                        DriverStation.getAlliance().isPresent()
+                                && DriverStation.getAlliance().get() == Alliance.Red
+                            ? Rotation2d.kZero
+                            : Rotation2d.kPi)))
+        .andThen(autoBuilder.getAutoCommand(drive));
   }
 }

--- a/src/main/java/com/team1165/robot/commands/RobotCommands.java
+++ b/src/main/java/com/team1165/robot/commands/RobotCommands.java
@@ -47,11 +47,11 @@ public class RobotCommands {
   private static final LoggedTunableNumber autoScorePrimaryDistanceToleranceBeforeScore =
       new LoggedTunableNumber("Commands/AutoScore/PrimaryDistanceTolerance", 0.04);
   private static final LoggedTunableNumber autoScorePrimaryDistanceDebounceBeforeScore =
-      new LoggedTunableNumber("Commands/AutoScore/PrimaryDistanceDebounceBeforeScore", 0.02);
+      new LoggedTunableNumber("Commands/AutoScore/PrimaryDistanceDebounceBeforeScore", 0.08);
   private static final LoggedTunableNumber autoScoreSecondaryDistanceToleranceBeforeScore =
       new LoggedTunableNumber("Commands/AutoScore/SecondaryDistanceToleranceBeforeScore", 0.09);
   private static final LoggedTunableNumber autoScoreSecondaryDistanceDebounceBeforeScore =
-      new LoggedTunableNumber("Commands/AutoScore/SecondaryDistanceDebounceBeforeScore", 0.10);
+      new LoggedTunableNumber("Commands/AutoScore/SecondaryDistanceDebounceBeforeScore", 0.18);
   private static final LoggedTunableNumber autoScoreElevatorToleranceBeforeScore =
       new LoggedTunableNumber("Commands/AutoScore/ElevatorToleranceBeforeScore", 0.15);
   private static final LoggedTunableNumber autoScoreClosePoseOffset =

--- a/src/main/java/com/team1165/robot/commands/RobotCommands.java
+++ b/src/main/java/com/team1165/robot/commands/RobotCommands.java
@@ -161,21 +161,16 @@ public class RobotCommands {
     var driveToInitialReefPosition =
         // Drive close to the reef until elevator is safe to move all the way to the reef
         new DriveToPoseProfiled(
-                drive,
-                () ->
-                    face.get()
-                        .getPose()
-                        .transformBy(
-                            new Transform2d(autoScoreFirstPoseOffset.get(), 0.0, Rotation2d.kZero)))
-            .withDeadline(
-                // Wait until ready to raise the elevator, raise elevator, wait until safe to move
-                new ChezySequenceCommandGroup(
-                    new WaitUntilCommand(readyToRaiseElevator),
-                    setLevelState(robot, level),
-                    new WaitUntilCommand(readyToMoveCloseToReef)));
+            drive,
+            () ->
+                face.get()
+                    .getPose()
+                    .transformBy(
+                        new Transform2d(autoScoreFirstPoseOffset.get(), 0.0, Rotation2d.kZero)));
     var driveAndScore =
         // Drive to final scoring position and score once ready
-        new DriveToPoseProfiled(drive, () -> face.get().getPose())
+        new DriveToPoseProfiled(
+                drive, () -> face.get().getPose(), driveToInitialReefPosition::getCurrentState)
             .withDeadline(
                 new ChezySequenceCommandGroup(
                     new WaitUntilCommand(readyToScore), score(robot, false, 0.35)));
@@ -203,7 +198,15 @@ public class RobotCommands {
 
     // Assemble commands into group
     return new ChezySequenceCommandGroup(
-        initializationCommand, driveToInitialReefPosition, driveAndScore, scoreFallback);
+        initializationCommand,
+        driveToInitialReefPosition.withDeadline(
+            // Wait until ready to raise the elevator, raise elevator, wait until safe to move
+            new ChezySequenceCommandGroup(
+                new WaitUntilCommand(readyToRaiseElevator),
+                setLevelState(robot, level),
+                new WaitUntilCommand(readyToMoveCloseToReef))),
+        driveAndScore,
+        scoreFallback);
   }
 
   public static Command oldAutoScore(

--- a/src/main/java/com/team1165/robot/commands/drivetrain/DriveToPoseProfiled.java
+++ b/src/main/java/com/team1165/robot/commands/drivetrain/DriveToPoseProfiled.java
@@ -28,7 +28,7 @@ public class DriveToPoseProfiled extends Command {
   private final ProfiledPIDController translationController =
       new ProfiledPIDController(3.0, 0.0, 0.0, new TrapezoidProfile.Constraints(4.5, 6.5));
   private final ProfiledPIDController rotationController =
-      new ProfiledPIDController(7.0, 0.0, 0.0, new TrapezoidProfile.Constraints(4, 6));
+      new ProfiledPIDController(7.0, 0.0, 0.0, new TrapezoidProfile.Constraints(5, 6));
 
   public DriveToPoseProfiled(Drive drive, Supplier<Pose2d> pose) {
     this.drive = drive;

--- a/src/main/java/com/team1165/robot/commands/drivetrain/DriveToPoseProfiled.java
+++ b/src/main/java/com/team1165/robot/commands/drivetrain/DriveToPoseProfiled.java
@@ -16,12 +16,15 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.wpilibj2.command.Command;
+import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 import org.littletonrobotics.junction.Logger;
 
 public class DriveToPoseProfiled extends Command {
   private final Drive drive;
   private final Supplier<Pose2d> pose;
+
+  private DoubleSupplier previousVelocity;
 
   private final ProfiledPIDController translationController =
       new ProfiledPIDController(3.0, 0.0, 0.0, new TrapezoidProfile.Constraints(4.5, 6.5));
@@ -38,6 +41,16 @@ public class DriveToPoseProfiled extends Command {
     addRequirements(this.drive);
   }
 
+  public DriveToPoseProfiled(Drive drive, Supplier<Pose2d> pose, DoubleSupplier previousVelocity) {
+    this(drive, pose);
+    this.previousVelocity = previousVelocity;
+  }
+
+  public DriveToPoseProfiled(Drive drive, Supplier<Pose2d> pose, DoubleSupplier previousVelocity, TrapezoidProfile.Constraints constraints) {
+    this(drive, pose, previousVelocity);
+    translationController.setConstraints(constraints);
+  }
+
   @Override
   public void initialize() {
     var currentPose = drive.getPose();
@@ -51,18 +64,24 @@ public class DriveToPoseProfiled extends Command {
     rotationController.reset(
         drive.getPose().getRotation().getRadians(), drive.getSpeeds().omegaRadiansPerSecond);
 
-    translationController.reset(
-        currentPose.getTranslation().getDistance(pose.get().getTranslation()),
-        Math.min(
-            0.0,
-            -linearFieldVelocity
-                .rotateBy(
-                    pose.get()
-                        .getTranslation()
-                        .minus(currentPose.getTranslation())
-                        .getAngle()
-                        .unaryMinus())
-                .getX()));
+    if (previousVelocity != null) {
+      translationController.reset(
+          currentPose.getTranslation().getDistance(pose.get().getTranslation()),
+          previousVelocity.getAsDouble());
+    } else {
+      translationController.reset(
+          currentPose.getTranslation().getDistance(pose.get().getTranslation()),
+          Math.min(
+              0.0,
+              -linearFieldVelocity
+                  .rotateBy(
+                      pose.get()
+                          .getTranslation()
+                          .minus(currentPose.getTranslation())
+                          .getAngle()
+                          .unaryMinus())
+                  .getX()));
+    }
 
     lastSetpointTranslation = currentPose.getTranslation();
   }
@@ -109,6 +128,10 @@ public class DriveToPoseProfiled extends Command {
 
     Logger.recordOutput("DriveToPose/ChassisSpeeds", chassisSpeeds);
     drive.runRobotSpeeds(chassisSpeeds);
+  }
+
+  public double getCurrentVelocitySetpoint() {
+    return translationController.getSetpoint().velocity;
   }
 
   @Override

--- a/src/main/java/com/team1165/robot/commands/drivetrain/DriveToPoseProfiled.java
+++ b/src/main/java/com/team1165/robot/commands/drivetrain/DriveToPoseProfiled.java
@@ -16,7 +16,6 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.wpilibj2.command.Command;
-import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 import org.littletonrobotics.junction.Logger;
 
@@ -24,14 +23,12 @@ public class DriveToPoseProfiled extends Command {
   private final Drive drive;
   private final Supplier<Pose2d> pose;
 
-  private DoubleSupplier previousVelocity;
+  private Supplier<TrapezoidProfile.State> previousState;
 
   private final ProfiledPIDController translationController =
       new ProfiledPIDController(3.0, 0.0, 0.0, new TrapezoidProfile.Constraints(4.5, 6.5));
   private final ProfiledPIDController rotationController =
       new ProfiledPIDController(7.0, 0.0, 0.0, new TrapezoidProfile.Constraints(4, 6));
-
-  private Translation2d lastSetpointTranslation = Translation2d.kZero;
 
   public DriveToPoseProfiled(Drive drive, Supplier<Pose2d> pose) {
     this.drive = drive;
@@ -41,13 +38,18 @@ public class DriveToPoseProfiled extends Command {
     addRequirements(this.drive);
   }
 
-  public DriveToPoseProfiled(Drive drive, Supplier<Pose2d> pose, DoubleSupplier previousVelocity) {
+  public DriveToPoseProfiled(
+      Drive drive, Supplier<Pose2d> pose, Supplier<TrapezoidProfile.State> previousState) {
     this(drive, pose);
-    this.previousVelocity = previousVelocity;
+    this.previousState = previousState;
   }
 
-  public DriveToPoseProfiled(Drive drive, Supplier<Pose2d> pose, DoubleSupplier previousVelocity, TrapezoidProfile.Constraints constraints) {
-    this(drive, pose, previousVelocity);
+  public DriveToPoseProfiled(
+      Drive drive,
+      Supplier<Pose2d> pose,
+      Supplier<TrapezoidProfile.State> previousState,
+      TrapezoidProfile.Constraints constraints) {
+    this(drive, pose, previousState);
     translationController.setConstraints(constraints);
   }
 
@@ -64,10 +66,8 @@ public class DriveToPoseProfiled extends Command {
     rotationController.reset(
         drive.getPose().getRotation().getRadians(), drive.getSpeeds().omegaRadiansPerSecond);
 
-    if (previousVelocity != null) {
-      translationController.reset(
-          currentPose.getTranslation().getDistance(pose.get().getTranslation()),
-          previousVelocity.getAsDouble());
+    if (previousState != null) {
+      translationController.reset(previousState.get());
     } else {
       translationController.reset(
           currentPose.getTranslation().getDistance(pose.get().getTranslation()),
@@ -82,36 +82,24 @@ public class DriveToPoseProfiled extends Command {
                           .unaryMinus())
                   .getX()));
     }
-
-    lastSetpointTranslation = currentPose.getTranslation();
   }
 
   @Override
   public void execute() {
+    // Get target and current pose
     var targetPose = pose.get();
     var currentPose = drive.getPose();
 
+    // Calculate the current distance away from the target pose
     double currentDistance = currentPose.getTranslation().getDistance(targetPose.getTranslation());
 
-    translationController.reset(
-        lastSetpointTranslation.getDistance(targetPose.getTranslation()),
-        translationController.getSetpoint().velocity);
-
+    // Calculate distance and rotation
     double translationVelocityScalar = translationController.calculate(currentDistance, 0.0);
     double rotationVelocity =
         rotationController.calculate(
             currentPose.getRotation().getRadians(), targetPose.getRotation().getRadians());
-    lastSetpointTranslation =
-        new Pose2d(
-                targetPose.getTranslation(),
-                currentPose.getTranslation().minus(targetPose.getTranslation()).getAngle())
-            .transformBy(
-                new Transform2d(
-                    translationController.getSetpoint().position, 0.0, Rotation2d.kZero))
-            .getTranslation();
 
-    Logger.recordOutput("DriveToPose/TargetPose", targetPose);
-
+    // Convert velocity to be based on the angle of movement
     var translationVelocity =
         new Pose2d(
                 Translation2d.kZero,
@@ -119,6 +107,7 @@ public class DriveToPoseProfiled extends Command {
             .transformBy(new Transform2d(translationVelocityScalar, 0.0, Rotation2d.kZero))
             .getTranslation();
 
+    // Create chassis speeds
     var chassisSpeeds =
         ChassisSpeeds.fromFieldRelativeSpeeds(
             translationVelocity.getX(),
@@ -126,12 +115,16 @@ public class DriveToPoseProfiled extends Command {
             rotationVelocity,
             currentPose.getRotation());
 
-    Logger.recordOutput("DriveToPose/ChassisSpeeds", chassisSpeeds);
+    // Run chassis speeds
     drive.runRobotSpeeds(chassisSpeeds);
+
+    // Log info
+    Logger.recordOutput("DriveToPose/TargetPose", targetPose);
+    Logger.recordOutput("DriveToPose/ChassisSpeeds", chassisSpeeds);
   }
 
-  public double getCurrentVelocitySetpoint() {
-    return translationController.getSetpoint().velocity;
+  public TrapezoidProfile.State getCurrentState() {
+    return translationController.getSetpoint();
   }
 
   @Override

--- a/src/main/java/com/team1165/robot/subsystems/drive/Drive.java
+++ b/src/main/java/com/team1165/robot/subsystems/drive/Drive.java
@@ -144,6 +144,12 @@ public class Drive extends SubsystemBase {
             - (inputs.Speeds.omegaRadiansPerSecond * (Timer.getTimestamp() - timestamp)));
   }
 
+  public Rotation2d getRawRotation(double timestamp) {
+    return inputs.RawHeading.minus(
+        Rotation2d.fromRadians(
+            inputs.Speeds.omegaRadiansPerSecond * (Timer.getTimestamp() - timestamp)));
+  }
+
   /**
    * Get the current {@link ChassisSpeeds} of the drivetrain.
    *

--- a/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVision.java
+++ b/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVision.java
@@ -28,7 +28,7 @@ import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Alert.AlertType;
 import edu.wpi.first.wpilibj.Timer;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj2.command.Command;
 import java.util.ArrayDeque;
 import java.util.Queue;
 import org.littletonrobotics.junction.Logger;
@@ -63,6 +63,9 @@ public class ATVision extends OverridableStateMachine<ATVisionState> {
       ATVisionConsumer globalConsumer,
       ATVisionRotationSupplier robotRotationSupplier,
       CameraConfig... config) {
+    // Call super from state machine
+    super(ATVisionState.SINGLE_TAG_3D);
+
     // Initialize consumer and supplier
     this.globalConsumer = globalConsumer;
     rotationSupplier = robotRotationSupplier;
@@ -91,6 +94,9 @@ public class ATVision extends OverridableStateMachine<ATVisionState> {
               "The AprilTag camera \"" + inputs[i].name + "\" (ID " + i + ") is disconnected.",
               AlertType.kWarning);
     }
+
+    // Specifically make sure we are set to SINGLE_TAG_3D before enabled for pose correction
+    setState(ATVisionState.SINGLE_TAG_3D);
   }
 
   @Override
@@ -323,9 +329,21 @@ public class ATVision extends OverridableStateMachine<ATVisionState> {
         "AprilTagVision/Summary/RobotPosesRejected", allRobotPosesRejected.toArray(new Pose3d[0]));
   }
 
-  public void enableSingleTagTrig() {
+  @Override
+  public Command overrideState(ATVisionState state) {
+    return super.overrideState(state).ignoringDisable(true);
+  }
+
+  private void setSingleTagTrig(boolean enable) {
     for (ATVisionIO visionIO : io) {
-      visionIO.setSingleTagTrig(true);
+      visionIO.setSingleTagTrig(enable);
+    }
+  }
+
+  protected void transition() {
+    switch (getCurrentState()) {
+      case SINGLE_TAG_3D -> setSingleTagTrig(false);
+      case SINGLE_TAG_TRIG -> setSingleTagTrig(true);
     }
   }
 

--- a/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVision.java
+++ b/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVision.java
@@ -12,6 +12,7 @@ import static com.team1165.robot.subsystems.vision.apriltag.constants.ATVisionCo
 import com.ctre.phoenix6.Utils;
 import com.team1165.robot.subsystems.vision.apriltag.io.ATVisionIO;
 import com.team1165.robot.subsystems.vision.apriltag.io.ATVisionIOInputsAutoLogged;
+import com.team1165.robot.util.statemachine.OverridableStateMachine;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -36,7 +37,7 @@ import org.littletonrobotics.junction.Logger;
  * A subsystem for a collection of cameras that estimates the pose of the robot with AprilTags
  * placed around the field.
  */
-public class ATVision extends SubsystemBase {
+public class ATVision extends OverridableStateMachine<ATVisionState> {
   // Alerts to send for each of the cameras if they get disconnected
   private final Alert[] disconnectedAlerts;
 
@@ -323,8 +324,8 @@ public class ATVision extends SubsystemBase {
   }
 
   public void enableSingleTagTrig() {
-    for (int i = 0; i < io.length; i++) {
-      io[i].setSingleTagTrig(true);
+    for (ATVisionIO visionIO : io) {
+      visionIO.setSingleTagTrig(true);
     }
   }
 

--- a/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVisionState.java
+++ b/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVisionState.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Team Paradise - FRC 1165 (https://github.com/TeamParadise)
+ *
+ * Use of this source code is governed by the MIT License, which can be found in the LICENSE file at
+ * the root directory of this project.
+ */
+
+package com.team1165.robot.subsystems.vision.apriltag;
+
+import com.team1165.robot.util.statemachine.State;
+
+/** All the possible states for the {@link ATVision} subsystem. */
+public enum ATVisionState implements State {
+  /** Single-tag vision without the trig-based gyro combination. Default PhotonVision method, more accurate up-close, less accurate when far away. */
+  SINGLE_TAG_3D(),
+  /** Single-tag vision with the trig-based gyro combination. More accurate further away, less accurate close up. */
+  SINGLE_TAG_TRIG()
+}

--- a/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVisionState.java
+++ b/src/main/java/com/team1165/robot/subsystems/vision/apriltag/ATVisionState.java
@@ -11,8 +11,14 @@ import com.team1165.robot.util.statemachine.State;
 
 /** All the possible states for the {@link ATVision} subsystem. */
 public enum ATVisionState implements State {
-  /** Single-tag vision without the trig-based gyro combination. Default PhotonVision method, more accurate up-close, less accurate when far away. */
+  /**
+   * Single-tag vision without the trig-based gyro combination. Default PhotonVision method, more
+   * accurate up-close, less accurate when far away.
+   */
   SINGLE_TAG_3D(),
-  /** Single-tag vision with the trig-based gyro combination. More accurate further away, less accurate close up. */
+  /**
+   * Single-tag vision with the trig-based gyro combination. More accurate further away, less
+   * accurate close up.
+   */
   SINGLE_TAG_TRIG()
 }

--- a/src/main/java/com/team1165/robot/subsystems/vision/apriltag/constants/ATVisionConstants.java
+++ b/src/main/java/com/team1165/robot/subsystems/vision/apriltag/constants/ATVisionConstants.java
@@ -36,8 +36,8 @@ public class ATVisionConstants {
 
   // Standard deviation baselines, for 1 meter distance and 1 tag
   // (Adjusted automatically based on distance and # of tags)
-  public static double linearStdDevBaseline = 0.015; // Meters
-  public static double angularStdDevBaseline = 0.03; // Radians
+  public static double linearStdDevBaseline = 0.02; // Meters
+  public static double angularStdDevBaseline = 0.05; // Radians
 
   public static double linearStdDevSingleTagBaseline = 0.02;
 }

--- a/src/main/java/com/team1165/robot/subsystems/vision/apriltag/constants/ATVisionConstants.java
+++ b/src/main/java/com/team1165/robot/subsystems/vision/apriltag/constants/ATVisionConstants.java
@@ -36,8 +36,8 @@ public class ATVisionConstants {
 
   // Standard deviation baselines, for 1 meter distance and 1 tag
   // (Adjusted automatically based on distance and # of tags)
-  public static double linearStdDevBaseline = 0.03; // Meters
-  public static double angularStdDevBaseline = 0.06; // Radians
+  public static double linearStdDevBaseline = 0.015; // Meters
+  public static double angularStdDevBaseline = 0.03; // Radians
 
   public static double linearStdDevSingleTagBaseline = 0.02;
 }

--- a/src/main/java/com/team1165/robot/util/auto/AutoRoutine.java
+++ b/src/main/java/com/team1165/robot/util/auto/AutoRoutine.java
@@ -16,6 +16,7 @@ import com.team1165.robot.subsystems.drive.Drive;
 import com.team1165.robot.util.commands.ChezySequenceCommandGroup;
 import com.team1165.robot.util.constants.RobotMode;
 import com.team1165.robot.util.constants.RobotMode.Mode;
+import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
@@ -40,9 +41,18 @@ public class AutoRoutine {
                 : Commands.none());
 
     for (AutoSegmentConfig segment : segments) {
+      var initialCoralStationCommand = new DriveToPoseProfiled(drive, () -> segment.coralStation().getPose());
+      var secondCoralStationCommand = new DriveToPoseProfiled(drive, () -> segment.coralStation().getPose(), initialCoralStationCommand::getCurrentVelocitySetpoint, new TrapezoidProfile.Constraints(2.0, 2.0));
+
       command.addCommands(
           RobotCommands.autoScore(robot, drive, segment::reefLocation, segment::reefLevel),
-          new DriveToPoseProfiled(drive, () -> segment.coralStation().getPose())
+          initialCoralStationCommand
+              .until(() -> drive
+                      .getPose()
+                      .getTranslation()
+                      .getDistance(
+                          segment.coralStation().getPose().getTranslation()) < 1.2)
+              .andThen(secondCoralStationCommand)
               .raceWith(
                   new ChezySequenceCommandGroup(
                       new WaitCommand(0.2),

--- a/src/main/java/com/team1165/robot/util/auto/AutoRoutine.java
+++ b/src/main/java/com/team1165/robot/util/auto/AutoRoutine.java
@@ -41,17 +41,25 @@ public class AutoRoutine {
                 : Commands.none());
 
     for (AutoSegmentConfig segment : segments) {
-      var initialCoralStationCommand = new DriveToPoseProfiled(drive, () -> segment.coralStation().getPose());
-      var secondCoralStationCommand = new DriveToPoseProfiled(drive, () -> segment.coralStation().getPose(), initialCoralStationCommand::getCurrentVelocitySetpoint, new TrapezoidProfile.Constraints(2.0, 2.0));
+      var initialCoralStationCommand =
+          new DriveToPoseProfiled(drive, () -> segment.coralStation().getPose());
+      var secondCoralStationCommand =
+          new DriveToPoseProfiled(
+              drive,
+              () -> segment.coralStation().getPose(),
+              initialCoralStationCommand::getCurrentState,
+              new TrapezoidProfile.Constraints(1.25, 2.0));
 
       command.addCommands(
           RobotCommands.autoScore(robot, drive, segment::reefLocation, segment::reefLevel),
           initialCoralStationCommand
-              .until(() -> drive
-                      .getPose()
-                      .getTranslation()
-                      .getDistance(
-                          segment.coralStation().getPose().getTranslation()) < 1.2)
+              .until(
+                  () ->
+                      drive
+                              .getPose()
+                              .getTranslation()
+                              .getDistance(segment.coralStation().getPose().getTranslation())
+                          < 1.8)
               .andThen(secondCoralStationCommand)
               .raceWith(
                   new ChezySequenceCommandGroup(

--- a/src/main/java/com/team1165/robot/util/statemachine/State.java
+++ b/src/main/java/com/team1165/robot/util/statemachine/State.java
@@ -18,5 +18,6 @@ import java.util.OptionalDouble;
 public interface State {
   default OptionalDouble get() {
     return OptionalDouble.empty();
-  };
+  }
+  ;
 }

--- a/src/main/java/com/team1165/robot/util/statemachine/State.java
+++ b/src/main/java/com/team1165/robot/util/statemachine/State.java
@@ -16,5 +16,7 @@ import java.util.OptionalDouble;
  * represents a distinct state that the {@link StateMachine} can be in.
  */
 public interface State {
-  OptionalDouble get();
+  default OptionalDouble get() {
+    return OptionalDouble.empty();
+  };
 }


### PR DESCRIPTION
Refine DriveToPoseProfiled to take values from previous profiled drive to pose commands in order to continue without stuttering/slowing down. Also, set lower velocity and acceleration limits when getting close to the coral station so hopefully, even if it still does hit the coral station, it should do it more lightly.

Closes #44.

Will test at driver practice on Sunday and then merge into develop. 